### PR TITLE
Add replica deletion protection for DynamoDB tables

### DIFF
--- a/.changelog/99999.txt
+++ b/.changelog/99999.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_dynamodb_table: Add `deletion_protection_enabled` argument to `replica` block
+```

--- a/internal/service/dynamodb/table.go
+++ b/internal/service/dynamodb/table.go
@@ -1571,21 +1571,21 @@ func updatePITR(ctx context.Context, conn *dynamodb.Client, tableName string, en
 }
 
 func updateReplicaDeletionProtection(ctx context.Context, conn *dynamodb.Client, tableName, region string, enabled bool, timeout time.Duration) error {
-       log.Printf("[DEBUG] Updating DynamoDB deletion protection to %v (%s)", enabled, region)
-       input := dynamodb.UpdateTableInput{
-               TableName:                 aws.String(tableName),
-               DeletionProtectionEnabled: aws.Bool(enabled),
-       }
-       optFn := func(o *dynamodb.Options) { o.Region = region }
-       if _, err := conn.UpdateTable(ctx, &input, optFn); err != nil {
-               return fmt.Errorf("updating deletion protection: %w", err)
-       }
+	log.Printf("[DEBUG] Updating DynamoDB deletion protection to %v (%s)", enabled, region)
+	input := dynamodb.UpdateTableInput{
+		TableName:                 aws.String(tableName),
+		DeletionProtectionEnabled: aws.Bool(enabled),
+	}
+	optFn := func(o *dynamodb.Options) { o.Region = region }
+	if _, err := conn.UpdateTable(ctx, &input, optFn); err != nil {
+		return fmt.Errorf("updating deletion protection: %w", err)
+	}
 
-       if _, err := waitReplicaActive(ctx, conn, tableName, region, timeout, replicaPropagationDelay); err != nil {
-               return fmt.Errorf("waiting for deletion protection update: %w", err)
-       }
+	if _, err := waitReplicaActive(ctx, conn, tableName, region, timeout, replicaPropagationDelay); err != nil {
+		return fmt.Errorf("waiting for deletion protection update: %w", err)
+	}
 
-       return nil
+	return nil
 }
 
 func updateReplica(ctx context.Context, conn *dynamodb.Client, d *schema.ResourceData) error {

--- a/internal/service/dynamodb/table.go
+++ b/internal/service/dynamodb/table.go
@@ -2269,8 +2269,6 @@ func flattenReplicaDescription(apiObject *awstypes.ReplicaDescription) map[strin
 		tfMap["region_name"] = aws.ToString(apiObject.RegionName)
 	}
 
-	tfMap["deletion_protection_enabled"] = apiObject.DeletionProtectionEnabled
-
 	return tfMap
 }
 

--- a/internal/service/dynamodb/table.go
+++ b/internal/service/dynamodb/table.go
@@ -1571,21 +1571,21 @@ func updatePITR(ctx context.Context, conn *dynamodb.Client, tableName string, en
 }
 
 func updateReplicaDeletionProtection(ctx context.Context, conn *dynamodb.Client, tableName, region string, enabled bool, timeout time.Duration) error {
-	log.Printf("[DEBUG] Updating DynamoDB deletion protection to %v (%s)", enabled, region)
-	input := dynamodb.UpdateTableInput{
-		TableName:                 aws.String(tableName),
-		DeletionProtectionEnabled: aws.Bool(enabled),
-	}
-	optFn := func(o *dynamodb.Options) { o.Region = region }
-	if _, err := conn.UpdateTable(ctx, &input, optFn); err != nil {
-		return fmt.Errorf("updating deletion protection: %w", err)
-	}
+       log.Printf("[DEBUG] Updating DynamoDB deletion protection to %v (%s)", enabled, region)
+       input := dynamodb.UpdateTableInput{
+               TableName:                 aws.String(tableName),
+               DeletionProtectionEnabled: aws.Bool(enabled),
+       }
+       optFn := func(o *dynamodb.Options) { o.Region = region }
+       if _, err := conn.UpdateTable(ctx, &input, optFn); err != nil {
+               return fmt.Errorf("updating deletion protection: %w", err)
+       }
 
-	if _, err := waitReplicaActive(ctx, conn, tableName, region, timeout, replicaPropagationDelay, optFn); err != nil {
-		return fmt.Errorf("waiting for deletion protection update: %w", err)
-	}
+       if _, err := waitReplicaActive(ctx, conn, tableName, region, timeout, replicaPropagationDelay); err != nil {
+               return fmt.Errorf("waiting for deletion protection update: %w", err)
+       }
 
-	return nil
+       return nil
 }
 
 func updateReplica(ctx context.Context, conn *dynamodb.Client, d *schema.ResourceData) error {

--- a/internal/service/dynamodb/table.go
+++ b/internal/service/dynamodb/table.go
@@ -305,6 +305,11 @@ func resourceTable() *schema.Resource {
 							Optional: true,
 							Default:  false,
 						},
+						"deletion_protection_enabled": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  false,
+						},
 						names.AttrPropagateTags: {
 							Type:     schema.TypeBool,
 							Optional: true,
@@ -1449,6 +1454,12 @@ func createReplicas(ctx context.Context, conn *dynamodb.Client, tableName string
 		if err = updatePITR(ctx, conn, tableName, tfMap["point_in_time_recovery"].(bool), nil, tfMap["region_name"].(string), timeout); err != nil {
 			return fmt.Errorf("updating replica (%s) point in time recovery: %w", tfMap["region_name"].(string), err)
 		}
+
+		if v, ok := tfMap["deletion_protection_enabled"].(bool); ok {
+			if err = updateReplicaDeletionProtection(ctx, conn, tableName, tfMap["region_name"].(string), v, timeout); err != nil {
+				return fmt.Errorf("updating replica (%s) deletion protection: %w", tfMap["region_name"].(string), err)
+			}
+		}
 	}
 
 	return nil
@@ -1559,6 +1570,24 @@ func updatePITR(ctx context.Context, conn *dynamodb.Client, tableName string, en
 	return nil
 }
 
+func updateReplicaDeletionProtection(ctx context.Context, conn *dynamodb.Client, tableName, region string, enabled bool, timeout time.Duration) error {
+	log.Printf("[DEBUG] Updating DynamoDB deletion protection to %v (%s)", enabled, region)
+	input := dynamodb.UpdateTableInput{
+		TableName:                 aws.String(tableName),
+		DeletionProtectionEnabled: aws.Bool(enabled),
+	}
+	optFn := func(o *dynamodb.Options) { o.Region = region }
+	if _, err := conn.UpdateTable(ctx, &input, optFn); err != nil {
+		return fmt.Errorf("updating deletion protection: %w", err)
+	}
+
+	if _, err := waitReplicaActive(ctx, conn, tableName, region, timeout, replicaPropagationDelay, optFn); err != nil {
+		return fmt.Errorf("waiting for deletion protection update: %w", err)
+	}
+
+	return nil
+}
+
 func updateReplica(ctx context.Context, conn *dynamodb.Client, d *schema.ResourceData) error {
 	oRaw, nRaw := d.GetChange("replica")
 	o := oRaw.(*schema.Set)
@@ -1629,6 +1658,14 @@ func updateReplica(ctx context.Context, conn *dynamodb.Client, d *schema.Resourc
 			if ma["point_in_time_recovery"].(bool) != mr["point_in_time_recovery"].(bool) {
 				if err := updatePITR(ctx, conn, d.Id(), ma["point_in_time_recovery"].(bool), nil, ma["region_name"].(string), d.Timeout(schema.TimeoutUpdate)); err != nil {
 					return fmt.Errorf("updating replica (%s) point in time recovery: %w", ma["region_name"].(string), err)
+				}
+				break
+			}
+
+			// just update deletion protection
+			if ma["deletion_protection_enabled"].(bool) != mr["deletion_protection_enabled"].(bool) {
+				if err := updateReplicaDeletionProtection(ctx, conn, d.Id(), ma["region_name"].(string), ma["deletion_protection_enabled"].(bool), d.Timeout(schema.TimeoutUpdate)); err != nil {
+					return fmt.Errorf("updating replica (%s) deletion protection: %w", ma["region_name"].(string), err)
 				}
 				break
 			}
@@ -1985,6 +2022,7 @@ func enrichReplicas(ctx context.Context, conn *dynamodb.Client, arn, tableName s
 
 		tfMap[names.AttrStreamARN] = aws.ToString(table.LatestStreamArn)
 		tfMap["stream_label"] = aws.ToString(table.LatestStreamLabel)
+		tfMap["deletion_protection_enabled"] = table.DeletionProtectionEnabled
 
 		if table.SSEDescription != nil {
 			tfMap[names.AttrKMSKeyARN] = aws.ToString(table.SSEDescription.KMSMasterKeyArn)
@@ -2230,6 +2268,8 @@ func flattenReplicaDescription(apiObject *awstypes.ReplicaDescription) map[strin
 	if apiObject.RegionName != nil {
 		tfMap["region_name"] = aws.ToString(apiObject.RegionName)
 	}
+
+	tfMap["deletion_protection_enabled"] = apiObject.DeletionProtectionEnabled
 
 	return tfMap
 }

--- a/internal/service/dynamodb/table_test.go
+++ b/internal/service/dynamodb/table_test.go
@@ -3134,6 +3134,66 @@ func TestAccDynamoDBTable_Replica_tagsUpdate(t *testing.T) {
 	})
 }
 
+func TestAccDynamoDBTable_Replica_deletionProtection(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var conf awstypes.TableDescription
+	resourceName := "aws_dynamodb_table.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckMultipleRegion(t, 3)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.DynamoDBServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5FactoriesMultipleRegions(ctx, t, 3),
+		CheckDestroy:             testAccCheckTableDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTableConfig_replicaDeletionProtection(rName, true),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckInitialTableExists(ctx, resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "replica.0.deletion_protection_enabled", acctest.CtTrue),
+					resource.TestCheckResourceAttr(resourceName, "replica.1.deletion_protection_enabled", acctest.CtTrue),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccTableConfig_replicaDeletionProtection(rName, false),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckInitialTableExists(ctx, resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "replica.0.deletion_protection_enabled", acctest.CtFalse),
+					resource.TestCheckResourceAttr(resourceName, "replica.1.deletion_protection_enabled", acctest.CtFalse),
+				),
+			},
+			{
+				Config: testAccTableConfig_replicaDeletionProtection(rName, true),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckInitialTableExists(ctx, resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "replica.0.deletion_protection_enabled", acctest.CtTrue),
+					resource.TestCheckResourceAttr(resourceName, "replica.1.deletion_protection_enabled", acctest.CtTrue),
+				),
+			},
+			{
+				Config: testAccTableConfig_replicaDeletionProtection(rName, false),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckInitialTableExists(ctx, resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "replica.0.deletion_protection_enabled", acctest.CtFalse),
+					resource.TestCheckResourceAttr(resourceName, "replica.1.deletion_protection_enabled", acctest.CtFalse),
+				),
+			},
+		},
+	})
+}
+
 func TestAccDynamoDBTable_tableClassInfrequentAccess(t *testing.T) {
 	ctx := acctest.Context(t)
 	var table awstypes.TableDescription
@@ -5183,6 +5243,43 @@ resource "aws_dynamodb_table" "test" {
   stream_view_type = %[3]s
 }
 `, rName, streamEnabled, viewType))
+}
+
+func testAccTableConfig_replicaDeletionProtection(rName string, deletionProtection bool) string {
+	return acctest.ConfigCompose(
+		acctest.ConfigMultipleRegionProvider(3),
+		fmt.Sprintf(`
+data "aws_region" "alternate" {
+  provider = "awsalternate"
+}
+
+data "aws_region" "third" {
+  provider = "awsthird"
+}
+
+resource "aws_dynamodb_table" "test" {
+  name             = %[1]q
+  hash_key         = "TestTableHashKey"
+  billing_mode     = "PAY_PER_REQUEST"
+  stream_enabled   = true
+  stream_view_type = "NEW_AND_OLD_IMAGES"
+
+  attribute {
+    name = "TestTableHashKey"
+    type = "S"
+  }
+
+  replica {
+    region_name                 = data.aws_region.alternate.name
+    deletion_protection_enabled = %[2]t
+  }
+
+  replica {
+    region_name                 = data.aws_region.third.name
+    deletion_protection_enabled = %[2]t
+  }
+}
+`, rName, deletionProtection))
 }
 
 func testAccTableConfig_lsi(rName, lsiName string) string {

--- a/website/docs/r/dynamodb_table.html.markdown
+++ b/website/docs/r/dynamodb_table.html.markdown
@@ -264,6 +264,7 @@ The following arguments are optional:
   **Note:** This attribute will _not_ be populated with the ARN of _default_ keys.
   **Note:** Changing this value will recreate the replica.
 * `point_in_time_recovery` - (Optional) Whether to enable Point In Time Recovery for the replica. Default is `false`.
+* `deletion_protection_enabled` - (Optional) Whether deletion protection is enabled (true) or disabled (false) on the replica. Default is `false`.
 * `propagate_tags` - (Optional) Whether to propagate the global table's tags to a replica.
   Default is `false`.
   Changes to tags only move in one direction: from global (source) to replica.


### PR DESCRIPTION
## Summary
- allow configuring `deletion_protection_enabled` inside the `replica` block
- propagate deletion protection value during read
- update and create replicas to apply deletion protection
- add acceptance test for replica deletion protection
- document new replica argument

## Testing
- `go test ./...` *(fails: go.mod requires go >= 1.24.4)*

------
https://chatgpt.com/codex/tasks/task_e_685eff58977c832fb93e781e4fe0c69b